### PR TITLE
Don't auto-load default maps

### DIFF
--- a/autoload/transcribe/helper.vim
+++ b/autoload/transcribe/helper.vim
@@ -5,6 +5,7 @@ endfunction
 
 function! s:load_media_control(media, mode) abort
   call _transcribe_load(a:media, a:mode)
+  call s:init_default_mappings()
   call s:load_timepos_control()
 
   command! -nargs=0 TranscribePause
@@ -81,3 +82,44 @@ function! s:toggle_sync_mode() abort
     augroup END
   endif
 endfunction
+
+function! s:init_default_mappings()
+  if exists('b:transcribe_maps_set')
+    return
+  endif
+  let b:transcribe_maps_set = 1
+
+  function! s:map(mode, lhs, rhs, ...)
+    if !hasmapto(a:rhs, a:mode)
+          \ && ((a:0 > 0) || (maparg(a:lhs, a:mode) ==# ''))
+      silent execute a:mode . 'map <silent><buffer>' a:lhs a:rhs
+    endif
+  endfunction
+
+  if g:transcribe_localleader
+    let l:prefix = '<localleader>'
+  else
+    let l:prefix = '<leader>'
+  endif
+
+  call s:map('n', l:prefix . '<space>', '<plug>(transcribe-toggle-pause)')
+  call s:map('i', '<C-space>', '<plug>(transcribe-toggle-pause)')
+
+  call s:map('n', l:prefix . 'k', '<plug>(transcribe-speed-inc)')
+  call s:map('i', '<C-k>', '<plug>(transcribe-speed-inc)')
+  call s:map('n', l:prefix . 'j', '<plug>(transcribe-speed-dec)')
+  call s:map('i', '<C-j>', '<plug>(transcribe-speed-dec)')
+
+  call s:map('n', l:prefix . 'l', '<plug>(transcribe-seek-forward)')
+  call s:map('i', '<C-l>', '<plug>(transcribe-seek-forward)')
+  call s:map('n', l:prefix . 'h', '<plug>(transcribe-seek-backward)')
+  call s:map('i', '<C-h>', '<plug>(transcribe-seek-backward)')
+
+  call s:map('n', l:prefix . 'p', '<plug>(transcribe-progress)')
+  call s:map('i', '<C-t>', '<plug>(transcribe-timepos-get)')
+  call s:map('n', l:prefix . 'gw', '<plug>(transcribe-timepos-curword)')
+  call s:map('n', l:prefix . 'gl', '<plug>(transcribe-timepos-curline)')
+  call s:map('i', '<C-l>', '<plug>(transcribe-timepos-curline)')
+  call s:map('n', l:prefix . 'ms', '<plug>(transcribe-sync-mode)')
+endfunction
+

--- a/autoload/transcribe/init.vim
+++ b/autoload/transcribe/init.vim
@@ -1,43 +1,6 @@
 function! transcribe#init#general()
   call s:init_options()
-  call s:init_default_mappings()
-
   call transcribe#helper#load_media()
-endfunction
-
-function! s:init_default_mappings()
-  function! s:map(mode, lhs, rhs, ...)
-    if !hasmapto(a:rhs, a:mode)
-          \ && ((a:0 > 0) || (maparg(a:lhs, a:mode) ==# ''))
-      silent execute a:mode . 'map <silent><buffer>' a:lhs a:rhs
-    endif
-  endfunction
-
-  if g:transcribe_localleader
-    let l:prefix = '<localleader>'
-  else
-    let l:prefix = '<leader>'
-  endif
-
-  call s:map('n', l:prefix . '<space>', '<plug>(transcribe-toggle-pause)')
-  call s:map('i', '<C-space>', '<plug>(transcribe-toggle-pause)')
-
-  call s:map('n', l:prefix . 'k', '<plug>(transcribe-speed-inc)')
-  call s:map('i', '<C-k>', '<plug>(transcribe-speed-inc)')
-  call s:map('n', l:prefix . 'j', '<plug>(transcribe-speed-dec)')
-  call s:map('i', '<C-j>', '<plug>(transcribe-speed-dec)')
-
-  call s:map('n', l:prefix . 'l', '<plug>(transcribe-seek-forward)')
-  call s:map('i', '<C-l>', '<plug>(transcribe-seek-forward)')
-  call s:map('n', l:prefix . 'h', '<plug>(transcribe-seek-backward)')
-  call s:map('i', '<C-h>', '<plug>(transcribe-seek-backward)')
-
-  call s:map('n', l:prefix . 'p', '<plug>(transcribe-progress)')
-  call s:map('i', '<C-t>', '<plug>(transcribe-timepos-get)')
-  call s:map('n', l:prefix . 'gw', '<plug>(transcribe-timepos-curword)')
-  call s:map('n', l:prefix . 'gl', '<plug>(transcribe-timepos-curline)')
-  call s:map('i', '<C-l>', '<plug>(transcribe-timepos-curline)')
-  call s:map('n', l:prefix . 'ms', '<plug>(transcribe-sync-mode)')
 endfunction
 
 function! s:init_options()


### PR DESCRIPTION
When the plugin loads it was setting the default maps for every
buffer whether an audio file had been loaded with TranscibeAudio or not
so that typing, for example, <C-l> in insert mode would insert the text "<plug>(transcribe-seek-forward)" literally.

Worse, because the default mappings map <C-h>, loading the plugin
rendered the backspace key inoperative for any terminal that sends
backspace as ^H.

This changeset causes the default mappings to be set only the first time :TranscribeAudio is used per buffer. It is how I've fixed things for my setup for now, but there may be a more standard way of handling plugin default mappings.